### PR TITLE
Perform a full clone if no branch is provided.

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -71,7 +71,7 @@ clone() {
   status "Cloning..."
   # Clone the given branch and checkout the sha.
   if [ -z "$BRANCH" ]; then
-    git clone --depth 50 "git@github.com:${REPOSITORY}.git" "$REPOSITORY"
+    git clone "git@github.com:${REPOSITORY}.git" "$REPOSITORY"
   else
     git clone --depth 50 --branch="$BRANCH" "git@github.com:${REPOSITORY}.git" "$REPOSITORY"
   fi


### PR DESCRIPTION
If no branch is provided and we shallow clone, it's possible that the sha won't be in the tree and the build will fail with `fatal: <sha> not in tree`. Instead, we should do a full clone.
