### PR TITLE
Use Docker 1.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 581
 RUN mkdir -p /etc/apt/sources.list.d && \
     echo deb https://apt.dockerproject.org/repo ubuntu-trusty main > /etc/apt/sources.list.d/docker.list
 RUN apt-get update && apt-get install -q -y \
-    docker-engine=1.8.1-0~trusty
+    docker-engine=1.10.0-0~trusty
 ADD ./bin/build /bin/build
 ADD ./bin/wrapdocker /bin/wrapdocker
 

--- a/bin/wrapdocker
+++ b/bin/wrapdocker
@@ -97,9 +97,9 @@ then
 else
 	if [ "$LOG" == "file" ]
 	then
-		docker -d $DOCKER_DAEMON_ARGS &>/var/log/docker.log &
+		docker daemon $DOCKER_DAEMON_ARGS &>/var/log/docker.log &
 	else
-		docker -d $DOCKER_DAEMON_ARGS &
+		docker daemon $DOCKER_DAEMON_ARGS &
 	fi
 	(( timeout = 60 + SECONDS ))
 	until docker info >/dev/null 2>&1


### PR DESCRIPTION
Closes https://github.com/remind101/conveyor-builder/issues/2

Docker 1.10.0 was [released](https://blog.docker.com/2016/02/docker-1-10/) today. Among the features is improved push/pull performance:

> **Improved push/pull performance and reliability**: Layers are now pushed in parallel, resulting in much faster pushes (as much as 3x faster). Pulls are a bit faster and more reliable too – with a streamlined protocol and better retry and fallback mechanisms.

This works locally for me, but we should not merge until we've tested this in a production environment for a bit
